### PR TITLE
Change Molecule.nelec to the total number of electrons

### DIFF
--- a/examples/br_example.py
+++ b/examples/br_example.py
@@ -42,7 +42,7 @@ tei = np.einsum("up, vq, uvkl, kr, ls -> prsq", C, C, mol.aoeri, C, C, optimize=
 hamiltonian = mol.hamiltonian(oei=oei, tei=tei)
 
 # Check that the hamiltonian with a HF reference ansatz doesn't yield the correct HF energy
-circuit = hf_circuit(mol.nso, sum(mol.nelec))
+circuit = hf_circuit(mol.nso, mol.nelec)
 print(
     f"\nElectronic energy: {expectation(circuit, hamiltonian):.8f} (From the H_core guess, should be > actual HF energy)"
 )
@@ -52,14 +52,14 @@ def electronic_energy(parameters):
     """
     Loss function (Electronic energy) for the basis rotation ansatz
     """
-    circuit = hf_circuit(mol.nso, sum(mol.nelec))
-    circuit += br_circuit(mol.nso, parameters, sum(mol.nelec))
+    circuit = hf_circuit(mol.nso, mol.nelec)
+    circuit += br_circuit(mol.nso, parameters, mol.nelec)
 
     return expectation(circuit, hamiltonian)
 
 
 # Build  a basis rotation_circuit
-params = np.random.rand(sum(mol.nelec) * (mol.nso - sum(mol.nelec)))  # n_occ * n_virt
+params = np.random.rand(mol.nelec * (mol.nso - mol.nelec))  # n_occ * n_virt
 
 best, params, extra = optimize(electronic_energy, params)
 
@@ -70,7 +70,7 @@ print(f"VQE energy: {best:.8f} (Basis rotation ansatz)")
 # print("Optimized parameters:", params)
 
 
-params = np.random.rand(sum(mol.nelec) * (mol.nso - sum(mol.nelec)))  # n_occ * n_virt
+params = np.random.rand(mol.nelec * (mol.nso - mol.nelec))  # n_occ * n_virt
 
 result = minimize(electronic_energy, params)
 best, params = result.fun, result.x

--- a/tests/test_basis_rotation.py
+++ b/tests/test_basis_rotation.py
@@ -82,12 +82,12 @@ def test_br_ansatz():
 
     # Define quantum circuit
     circuit = Circuit(mol.nso)
-    circuit.add(gates.X(_i) for _i in range(sum(mol.nelec)))
+    circuit.add(gates.X(_i) for _i in range(mol.nelec))
 
     # Add basis rotation ansatz
     # Initialize all at zero
-    parameters = np.zeros(sum(mol.nelec) * (mol.nso - sum(mol.nelec)))  # n_occ * n_virt
-    circuit += basis_rotation.br_circuit(mol.nso, parameters, sum(mol.nelec))
+    parameters = np.zeros(mol.nelec * (mol.nso - mol.nelec))  # n_occ * n_virt
+    circuit += basis_rotation.br_circuit(mol.nso, parameters, mol.nelec)
 
     def electronic_energy(parameters):
         """

--- a/tests/test_hardware_efficient.py
+++ b/tests/test_hardware_efficient.py
@@ -21,7 +21,7 @@ def test_hea_ansatz():
 
     hea_ansatz = hardware_efficient.hea(nlayers, nqubits)
     qc = models.Circuit(nqubits)
-    qc.add(gates.X(_i) for _i in range(sum(mol.nelec)))
+    qc.add(gates.X(_i) for _i in range(mol.nelec))
     qc.add(hea_ansatz)
     qc.set_parameters(theta)
 
@@ -46,7 +46,7 @@ def test_vqe_hea_ansatz():
 
     hea_ansatz = hardware_efficient.hea(nlayers, nqubits, ["RY", "RZ"], "CNOT")
     qc = models.Circuit(nqubits)
-    qc.add(gates.X(_i) for _i in range(sum(mol.nelec)))
+    qc.add(gates.X(_i) for _i in range(mol.nelec))
     qc.add(hea_ansatz)
     qc.set_parameters(theta)
 

--- a/tests/test_hf_circuit.py
+++ b/tests/test_hf_circuit.py
@@ -19,7 +19,7 @@ def test_jw_circuit():
     h2.run_pyscf()
 
     # JW-HF circuit
-    circuit = hf_circuit(h2.nso, sum(h2.nelec), ferm_qubit_map=None)
+    circuit = hf_circuit(h2.nso, h2.nelec, ferm_qubit_map=None)
 
     # Molecular Hamiltonian and the HF expectation value
     hamiltonian = h2.hamiltonian()
@@ -38,7 +38,7 @@ def test_bk_circuit_1():
     h2.run_pyscf()
 
     # JW-HF circuit
-    circuit = hf_circuit(h2.nso, sum(h2.nelec), ferm_qubit_map="bk")
+    circuit = hf_circuit(h2.nso, h2.nelec, ferm_qubit_map="bk")
 
     # Molecular Hamiltonian and the HF expectation value
     hamiltonian = h2.hamiltonian(ferm_qubit_map="bk")
@@ -55,7 +55,7 @@ def test_bk_circuit_2():
     lih.run_pyscf()
 
     # JW-HF circuit
-    circuit = hf_circuit(lih.nso, sum(lih.nelec), ferm_qubit_map="bk")
+    circuit = hf_circuit(lih.nso, lih.nelec, ferm_qubit_map="bk")
 
     # Molecular Hamiltonian and the HF expectation value
     hamiltonian = lih.hamiltonian(ferm_qubit_map="bk")

--- a/tests/test_molecule.py
+++ b/tests/test_molecule.py
@@ -213,18 +213,28 @@ def test_symbolic_hamiltonian():
     assert np.allclose(h2_sym_ham.matrix, ref_sym_ham.matrix)
 
 
-@pytest.mark.skip(reason="Psi4 doesn't offer pip install, so needs to be installed through conda or manually.")
-def test_run_psi4():
-    """PSI4 driver"""
-    # Hardcoded benchmark results
-    h2_ref_energy = -1.117349035
-    h2_ref_hcore = np.array([[-1.14765024, -1.00692423], [-1.00692423, -1.14765024]])
-
+def test_hamiltonian_input_error():
     h2 = Molecule([("H", (0.0, 0.0, 0.0)), ("H", (0.0, 0.0, 0.7))])
-    h2.run_psi4()
+    h2.e_nuc = 0.0
+    h2.oei = np.random.rand(4, 4)
+    h2.tei = np.random.rand(4, 4, 4, 4)
+    with pytest.raises(NameError):
+        h2.hamiltonian("ihpc")
 
-    assert h2.e_hf == pytest.approx(h2_ref_energy)
-    assert np.allclose(h2.hcore, h2_ref_hcore)
+
+# Commenting out since not actively supporting PSI4 at the moment
+# @pytest.mark.skip(reason="Psi4 doesn't offer pip install, so needs to be installed through conda or manually.")
+# def test_run_psi4():
+#     """PSI4 driver"""
+#     # Hardcoded benchmark results
+#     h2_ref_energy = -1.117349035
+#     h2_ref_hcore = np.array([[-1.14765024, -1.00692423], [-1.00692423, -1.14765024]])
+#
+#     h2 = Molecule([("H", (0.0, 0.0, 0.0)), ("H", (0.0, 0.0, 0.7))])
+#     h2.run_psi4()
+#
+#     assert h2.e_hf == pytest.approx(h2_ref_energy)
+#     assert np.allclose(h2.hcore, h2_ref_hcore)
 
 
 def test_expectation_value():
@@ -237,7 +247,7 @@ def test_expectation_value():
 
     # JW-HF circuit
     circuit = models.Circuit(h2.nso)
-    circuit.add(gates.X(_i) for _i in range(sum(h2.nelec)))
+    circuit.add(gates.X(_i) for _i in range(h2.nelec))
     # Molecular Hamiltonian and the HF expectation value
     hamiltonian = h2.hamiltonian()
     hf_energy = expectation(circuit, hamiltonian)


### PR DESCRIPTION
This was done in response to feedback on Qibochem from my Dec 2023 RAP attachment students.

First, they asked what's `.nso` and `.nelec`: Documentation for these class attributes was missing.
Follow-up question: why are all the .n* attributes integers, except for `.nelec`, which is currently `(nalpha, nbeta)`?

Hence, I changed `.nelec` to the total number of electrons directly.

Also: Added documentation for some other Molecule class attributes that are potentially useful.