### PR TITLE
Ungroup `Z` terms

### DIFF
--- a/doc/source/api-reference/measurement.rst
+++ b/doc/source/api-reference/measurement.rst
@@ -18,7 +18,7 @@ Measurement cost reduction
 --------------------------
 
 The following functions are used for reducing and optimising the measurement cost of obtaining the Hamiltonian
-expectation value when sample measurements are used.
+expectation value using sample measurements instead of a state vector simulation.
 
 .. autofunction:: qibochem.measurement.optimization.measurement_basis_rotations
 

--- a/examples/br_example.py
+++ b/examples/br_example.py
@@ -8,7 +8,7 @@ from qibo.models import VQE
 
 from qibochem.ansatz import basis_rotation, hf_circuit
 from qibochem.driver import Molecule
-from qibochem.measurement.expectation import expectation
+from qibochem.measurement import expectation
 
 # Define molecule and populate
 mol = Molecule(xyz_file="h3p.xyz")

--- a/examples/ucc_example1.py
+++ b/examples/ucc_example1.py
@@ -7,8 +7,8 @@ from qibo.optimizers import optimize
 from scipy.optimize import minimize
 
 from qibochem.ansatz import hf_circuit, ucc_circuit
-from qibochem.driver.molecule import Molecule
-from qibochem.measurement.expectation import expectation
+from qibochem.driver import Molecule
+from qibochem.measurement import expectation
 
 # Define molecule and populate
 mol = Molecule(xyz_file="lih.xyz")

--- a/src/qibochem/measurement/optimization.py
+++ b/src/qibochem/measurement/optimization.py
@@ -122,7 +122,7 @@ def measurement_basis_rotations(hamiltonian, grouping=None):
 
     Args:
         hamiltonian (SymbolicHamiltonian): Hamiltonian of interest
-        grouping: Whether or not to group the X/Y terms together, i.e. use the same set of measurements to get the
+        grouping: Whether or not to group Hamiltonian terms together, i.e. use the same set of measurements to get the
             expectation values of a group of terms simultaneously. Default value of ``None`` will not group any terms
             together, while ``"qwc"`` will group qubitwise commuting terms together, and return the measurement gates
             associated with each group of X/Y terms

--- a/src/qibochem/measurement/optimization.py
+++ b/src/qibochem/measurement/optimization.py
@@ -88,9 +88,14 @@ def qwc_measurement_gates(grouped_terms):
     """
     m_gates = {}
     for term in grouped_terms:
-        for factor in term.factors:
-            if m_gates.get(factor.target_qubit) is None and factor.name[0] != "I":
-                m_gates[factor.target_qubit] = gates.M(factor.target_qubit, basis=type(factor.gate))
+        m_gates = {
+            **m_gates,
+            **{
+                factor.target_qubit: gates.M(factor.target_qubit, basis=type(factor.gate))
+                for factor in term.factors
+                if m_gates.get(factor.target_qubit) is None and factor.name[0] != "I"
+            },
+        }
     return list(m_gates.values())
 
 

--- a/src/qibochem/measurement/optimization.py
+++ b/src/qibochem/measurement/optimization.py
@@ -133,23 +133,12 @@ def measurement_basis_rotations(hamiltonian, grouping=None):
             will be two empty lists - ``([], [])`` - if there are no Z terms present.
     """
     result = []
-    # Split up the Z and X/Y terms
-    z_only_terms = [
-        term for term in hamiltonian.terms if not any(factor.name[0] in ("X", "Y") for factor in term.factors)
-    ]
-    xy_terms = [term for term in hamiltonian.terms if term not in z_only_terms]
-    # Add the Z terms into result first, followed by the terms with X/Y's
-    if z_only_terms:
-        result.append((qwc_measurement_gates(z_only_terms), z_only_terms))
+    if grouping is None:
+        result += [(qwc_measurement_gates([term]), [term]) for term in hamiltonian.terms]
+    elif grouping == "qwc":
+        result += qwc_measurements(hamiltonian.terms)
     else:
-        result.append(([], []))
-    if xy_terms:
-        if grouping is None:
-            result += [(qwc_measurement_gates([term]), [term]) for term in xy_terms]
-        elif grouping == "qwc":
-            result += qwc_measurements(xy_terms)
-        else:
-            raise NotImplementedError("Not ready yet!")
+        raise NotImplementedError("Not ready yet!")
     return result
 
 

--- a/src/qibochem/measurement/result.py
+++ b/src/qibochem/measurement/result.py
@@ -64,15 +64,15 @@ def expectation_from_samples(
         circuit (qibo.models.Circuit): Quantum circuit ansatz
         hamiltonian (qibo.hamiltonians.SymbolicHamiltonian): Molecular Hamiltonian
         n_shots (int): Number of times the circuit is run. Default: ``1000``
-        group_pauli_terms: Whether or not to group Pauli X/Y terms in the Hamiltonian together to reduce the measurement
-            cost. Available options: ``None``: (Default) Hamiltonian terms containing X/Y are not grouped together, and
+        group_pauli_terms: Whether or not to group Hamiltonian terms together to reduce the measurement
+            cost. Available options: ``None``: (Default) No grouping of Hamiltonian terms, and
             ``"qwc"``: Terms that commute qubitwise are grouped together
-        n_shots_per_pauli_term (bool): Whether or not ``n_shots`` is used for each Pauli term in the Hamiltonian, or for
-            *all* the terms in the Hamiltonian. Default: ``True``; ``n_shots`` are used to get the expectation value for each
-            term in the Hamiltonian.
-        shot_allocation: Iterable containing the number of shots to be allocated to each term in the Hamiltonian respectively if
-            n_shots_per_pauli_term is ``False``. Default: ``None``; shots are allocated based on the magnitudes of the coefficients
-            of the Hamiltonian terms.
+        n_shots_per_pauli_term (bool): Whether or not ``n_shots`` is used for each Pauli term (or group of terms) in the
+            Hamiltonian, or for *all* the (group of) terms in the Hamiltonian. Default: ``True``; ``n_shots`` are used
+            to get the expectation value for each term in the Hamiltonian.
+        shot_allocation: Iterable containing the number of shots to be allocated to each term (or group of terms) in the
+            Hamiltonian respectively if n_shots_per_pauli_term is ``False``. Default: ``None``; shots are allocated
+            based on the magnitudes of the coefficients of the Hamiltonian terms.
 
     Returns:
         float: Hamiltonian expectation value

--- a/src/qibochem/measurement/result.py
+++ b/src/qibochem/measurement/result.py
@@ -105,13 +105,7 @@ def expectation_from_samples(
             frequencies = result.frequencies(binary=True)
             qubit_map = sorted(qubit for gate in measurement_gates for qubit in gate.target_qubits)
             if frequencies:  # Needed because might have cases whereby no shots allocated to a group
-                # First term is all Z terms, can use expectation_from_samples directly.
-                if _i > 0:
-                    total += sum(pauli_term_measurement_expectation(term, frequencies, qubit_map) for term in terms)
-                # Otherwise, need to use the general pauli_term_measurement_expectation function
-                else:
-                    z_ham = SymbolicHamiltonian(sum(symbolic_term_to_symbol(term) for term in terms))
-                    total += z_ham.expectation_from_samples(frequencies, qubit_map=qubit_map)
+                total += sum(pauli_term_measurement_expectation(term, frequencies, qubit_map) for term in terms)
     # Add the constant term if present. Note: Energies (in chemistry) are all real values
     total += hamiltonian.constant.real
     return total

--- a/src/qibochem/measurement/result.py
+++ b/src/qibochem/measurement/result.py
@@ -31,11 +31,6 @@ def expectation(circuit: qibo.models.Circuit, hamiltonian: SymbolicHamiltonian):
     return hamiltonian.expectation(state_ket)
 
 
-def symbolic_term_to_symbol(symbolic_term):
-    """Convert a single Pauli word in the form of a Qibo SymbolicTerm to a Qibo Symbol"""
-    return symbolic_term.coefficient * reduce(lambda x, y: x * y, symbolic_term.factors, 1.0)
-
-
 def pauli_term_measurement_expectation(pauli_term, frequencies, qubit_map):
     """
     Calculate the expectation value of a single general Pauli string for some measurement frequencies


### PR DESCRIPTION
Removes the default grouping of all `Z` terms together when using `expectation_from_samples`.
Will probably add in a flag somewhere to do this optionally after some other measurement optimization schemes have been put in (e.g. the `gc_to_qwc` branch), but the current default is too restrictive.

Other changes:
- Edited parameters for some tests involving a bit of randomness, they should fail a lot less frequently
- Minor bug fixes in the example scripts