### PR TITLE
Increase noise tolerance for test_qwc_functionality

### DIFF
--- a/tests/test_expectation_samples.py
+++ b/tests/test_expectation_samples.py
@@ -139,7 +139,7 @@ def test_qwc_functionality(hamiltonian):
         n_shots=n_shots,
         group_pauli_terms="qwc",
     )
-    assert test == pytest.approx(expected, abs=0.05)
+    assert test == pytest.approx(expected, abs=0.08)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Increase noise tolerance for QWC error from 0.05 to 0.08, addressing Issue #137 .