### PR TITLE
Update sample variance calculation code

### DIFF
--- a/doc/source/api-reference/measurement.rst
+++ b/doc/source/api-reference/measurement.rst
@@ -14,6 +14,8 @@ Expectation value of Hamiltonian
 
 .. autofunction:: qibochem.measurement.result.expectation_from_samples
 
+.. autofunction:: qibochem.measurement.result.v_expectation
+
 Measurement cost reduction
 --------------------------
 
@@ -22,4 +24,9 @@ expectation value using sample measurements instead of a state vector simulation
 
 .. autofunction:: qibochem.measurement.optimization.measurement_basis_rotations
 
-.. autofunction:: qibochem.measurement.optimization.allocate_shots
+.. autofunction:: qibochem.measurement.shot_allocation.allocate_shots
+
+Utility functions
+-----------------
+
+.. autofunction:: qibochem.measurement.result.sample_statistics

--- a/src/qibochem/measurement/optimization.py
+++ b/src/qibochem/measurement/optimization.py
@@ -159,8 +159,8 @@ def measurement_basis_rotations(hamiltonian, grouping=None):
 
     Returns:
         list: List of two-tuples; the first item in the tuple is a group of Pauli terms (:class:`sympy.Expr`), and the
-            second is a list of measurement gates (:class:`qibo.gates.M`) that can be used to get the expectation value
-            for the corresponding expression.
+        second is a list of measurement gates (:class:`qibo.gates.M`) that can be used to get the expectation value
+        for the corresponding expression.
     """
     result = []
     if grouping is None:

--- a/src/qibochem/measurement/result.py
+++ b/src/qibochem/measurement/result.py
@@ -130,10 +130,10 @@ def expectation_from_samples(
 
 def sample_statistics(circuit, grouped_terms, n_shots=100):
     """
-    An alternative to `expectation_from_samples` to be used when both the expectation values and sample variances are of
-    interest. Unlike `expectation_from_samples`, this function does not have the flexibility of allocating shots
-    specifically to each term (group) in the Hamiltonian; a fixed number of shots (`n_shots`) will be allocated to each
-    term (group) instead.
+    An alternative to the :ref:`expectation_from_samples<expectation-samples>` function when both the expectation values
+    and sample variances are of interest. Unlike :ref:`expectation_from_samples<expectation-samples>`, this function
+    does not have the flexibility of allocating shots specifically to each term (group) in the Hamiltonian; a fixed
+    number of shots will be allocated to each term (group) instead.
 
     Args:
         circuit (:class:`qibo.models.Circuit`): Quantum circuit ansatz
@@ -143,8 +143,8 @@ def sample_statistics(circuit, grouped_terms, n_shots=100):
         n_shots (int): Number of times the circuit is run for each Hamiltonian term (group). Default: ``1000``
 
     Returns:
-        list: Sample expectation values for each Hamiltonian term (group) with respect to the given circuit
-        list: Sample variances for each Hamiltonian term (group) with respect to the given circuit
+        tuple: A two-tuple of lists, corresponding to the sample means (expectation values) and variances for each
+        Hamiltonian term (group) with respect to the given circuit.
     """
     expectation_values, expectation_variances = [], []
     for expression, measurement_gates in grouped_terms:
@@ -166,12 +166,15 @@ def sample_statistics(circuit, grouped_terms, n_shots=100):
 
 def v_expectation(circuit, hamiltonian, n_shots, n_trial_shots, grouping=None, method="vmsa"):
     """
-    Loss function for finding the expectation value of a Hamiltonian using shots. Shots are allocated according to the
-    Variance-Minimized Shot Assignment (VMSA) or Variance-Preserved Shot Reduction (VPSR) approaches suggested in the
-    reference paper (see below). Essentially, a uniform number of trial shots are first used to find the sample variance
-    for each term in the Hamiltonian. For the VMSA method, all the remaining shots after allocated after obtaining the
-    sample variance of each Hamiltonian term (group), while for the VPSR method, a sufficient number of shots are
-    allocated to each term (group) to keep their variance below a certain threshold, i.e. not all shots are allocated.
+    An alternative loss function for finding the expectation value of a Hamiltonian using shots. Shots are allocated
+    according to the Variance-Minimized Shot Assignment (VMSA) or Variance-Preserved Shot Reduction (VPSR) approaches
+    suggested in the reference paper (given below).
+
+    Essentially, a uniform number of trial shots are first used to find the sample variance for each term (group) in the
+    Hamiltonian. For the VMSA method, the remaining shots are all allocated to minimise the total variance (calculated
+    as the sum of the variances), while for the VPSR method, a sufficient number of shots are allocated to each term
+    (group) to keep their variance - and by extension, the total variance - below a certain threshold. Unlike in the
+    VMSA method, the VPSR method does not allocate all of the remaining shots.
 
     Args:
         circuit (:class:`qibo.models.Circuit`): Circuit ansatz for running VQE

--- a/src/qibochem/measurement/result.py
+++ b/src/qibochem/measurement/result.py
@@ -95,7 +95,7 @@ def expectation_from_samples(
         n_shots_per_pauli_term (bool): Whether or not ``n_shots`` is used for each Pauli term (or group of terms) in the
             Hamiltonian, or for *all* the (group of) terms in the Hamiltonian. Default: ``True``; ``n_shots`` are used
             to get the expectation value for each term (group of terms) in the Hamiltonian.
-        shot_allocation: Iterable containing the number of shots to be allocated to each term (or group of terms) in the
+        shot_allocation (list): Iterable containing the number of shots to be allocated to each term (or group of terms) in the
             Hamiltonian respectively if the `n_shots_per_pauli_term` argument is ``False``. Default: ``None``; shots are
             allocated based on the magnitudes of the coefficients of the Hamiltonian terms.
 
@@ -115,18 +115,56 @@ def expectation_from_samples(
 
     total = constant_term(hamiltonian)
     for _i, (expression, measurement_gates) in enumerate(grouped_terms):
-        if measurement_gates:
-            _circuit = circuit.copy()
-            _circuit.add(measurement_gates)
+        _circuit = circuit.copy()
+        _circuit.add(measurement_gates)
 
-            # Number of shots used to run the circuit depends on n_shots_per_pauli_term
-            result = _circuit(nshots=n_shots if n_shots_per_pauli_term else shot_allocation[_i])
+        # Number of shots used to run the circuit depends on n_shots_per_pauli_term
+        result = _circuit(nshots=n_shots if n_shots_per_pauli_term else shot_allocation[_i])
 
-            frequencies = result.frequencies(binary=True)
+        frequencies = result.frequencies(binary=True)
+        if frequencies:  # Needed because might have cases whereby no shots allocated to a group
             qubit_map = sorted(qubit for gate in measurement_gates for qubit in gate.target_qubits)
-            if frequencies:  # Needed because might have cases whereby no shots allocated to a group
-                total += pauli_term_measurement_expectation(expression, frequencies, qubit_map)
+            total += pauli_term_measurement_expectation(expression, frequencies, qubit_map)
     return total
+
+
+def sample_statistics(circuit, grouped_terms, n_shots=1000, grouping=None):
+    """
+    An alternative to `expectation_from_samples` to be used when both the expectation values and sample variances are of
+    interest. Unlike `expectation_from_samples`, this function does not have the flexibility of allocating shots
+    specifically to each term (group) in the Hamiltonian; a fixed number of shots (`n_shots`) will be allocated to each
+    term (group) instead.
+
+    Args:
+        circuit (:class:`qibo.models.Circuit`): Quantum circuit ansatz
+        grouped_terms (list): List of two-tuples; the first item in the tuple is a group of Pauli terms
+            (:class:`sympy.Expr`), and the second is a list of measurement gates (:class:`qibo.gates.M`) that can be
+            used to get the expectation value for the corresponding expression
+        n_shots (int): Number of times the circuit is run for each Hamiltonian term (group). Default: ``1000``
+        grouping (str): Whether or not to group Hamiltonian terms together to reduce the measurement
+            cost. Available options: ``None``: (Default) No grouping of Hamiltonian terms, and
+            ``"qwc"``: Terms that commute qubitwise are grouped together
+
+    Returns:
+        list: Sample expectation values for each Hamiltonian term (group) with respect to the given circuit
+        list: Sample variances for each Hamiltonian term (group) with respect to the given circuit
+    """
+    expectation_values, expectation_variances = [], []
+    for expression, measurement_gates in grouped_terms:
+        _circuit = circuit.copy()
+        _circuit.add(measurement_gates)
+        result = _circuit(nshots=n_shots)
+        frequencies = result.frequencies(binary=True)
+        qubit_map = sorted(qubit for gate in measurement_gates for qubit in gate.target_qubits)
+        # Calculate sample mean first, then iterate through the obtained result frequencies to get the sample variance
+        sample_mean = pauli_term_measurement_expectation(expression, frequencies, qubit_map)
+        sample_variance = sum(
+            (pauli_term_measurement_expectation(expression, {freq: count}, qubit_map) - sample_mean) ** 2
+            for freq, count in frequencies.items()
+        ) / (n_shots - 1)
+        expectation_values.append(sample_mean)
+        expectation_variances.append(sample_variance)
+    return expectation_values, expectation_variances
 
 
 def expectation_variance(circuit, hamiltonian, n_trial_shots, grouping):
@@ -177,12 +215,13 @@ def v_expectation(circuit, hamiltonian, n_shots, n_trial_shots, grouping=None, m
         n_trial_shots * len(grouped_terms) <= n_shots
     ), f"n(Trial shots = {n_trial_shots}) * n(Term groups = {len(grouped_terms)}) > n(Total shots = {n_shots})"
     # Sample means and variances for each term group, using n_trial_shots
-    sample_results = [
-        expectation_variance(circuit, SymbolicHamiltonian(expression), n_trial_shots, grouping=grouping)
-        for expression, _ in grouped_terms
-    ]
-    sample_means = [result[0] for result in sample_results]
-    sample_variances = [result[1] for result in sample_results]
+    # sample_results = [
+    #     expectation_variance(circuit, SymbolicHamiltonian(expression), n_trial_shots, grouping=grouping)
+    #     for expression, _ in grouped_terms
+    # ]
+    sample_means, sample_variances = sample_statistics(circuit, grouped_terms, n_shots=n_trial_shots, grouping=grouping)
+    # sample_means = [result[0] for result in sample_results]
+    # sample_variances = [result[1] for result in sample_results]
     # Assign remaining (n_shots - nH terms * n_trial_shots) based on the computed sample variances
     remaining_shot_allocation = allocate_shots_by_variance(n_shots, n_trial_shots, sample_variances, method=method)
     new_mean_values = [

--- a/src/qibochem/measurement/result.py
+++ b/src/qibochem/measurement/result.py
@@ -128,7 +128,7 @@ def expectation_from_samples(
     return total
 
 
-def sample_statistics(circuit, grouped_terms, n_shots=100, grouping=None):
+def sample_statistics(circuit, grouped_terms, n_shots=100):
     """
     An alternative to `expectation_from_samples` to be used when both the expectation values and sample variances are of
     interest. Unlike `expectation_from_samples`, this function does not have the flexibility of allocating shots
@@ -141,9 +141,6 @@ def sample_statistics(circuit, grouped_terms, n_shots=100, grouping=None):
             (:class:`sympy.Expr`), and the second is a list of measurement gates (:class:`qibo.gates.M`) that can be
             used to get the expectation value for the corresponding expression
         n_shots (int): Number of times the circuit is run for each Hamiltonian term (group). Default: ``1000``
-        grouping (str): Whether or not to group Hamiltonian terms together to reduce the measurement cost. Available
-            options: ``None``: (Default) No grouping of Hamiltonian terms, and ``"qwc"``: Terms that commute qubitwise
-            are grouped together
 
     Returns:
         list: Sample expectation values for each Hamiltonian term (group) with respect to the given circuit
@@ -202,7 +199,7 @@ def v_expectation(circuit, hamiltonian, n_shots, n_trial_shots, grouping=None, m
         n_trial_shots * len(grouped_terms) <= n_shots
     ), f"n(Trial shots = {n_trial_shots}) * n(Term groups = {len(grouped_terms)}) > n(Total shots = {n_shots})"
     # Sample means and variances for each term group, using n_trial_shots
-    sample_means, sample_variances = sample_statistics(circuit, grouped_terms, n_shots=n_trial_shots, grouping=grouping)
+    sample_means, sample_variances = sample_statistics(circuit, grouped_terms, n_shots=n_trial_shots)
     # Assign remaining (n_shots - nH terms * n_trial_shots) based on the computed sample variances
     remaining_shot_allocation = allocate_shots_by_variance(n_shots, n_trial_shots, sample_variances, method=method)
     new_mean_values = [


### PR DESCRIPTION
Fix for #144

Rough script that I used to compare the difference between the present branch and the main branch:
```
import timeit
import numpy as np

from qibochem.ansatz import he_circuit
from qibochem.driver import Molecule
from qibochem.measurement import v_expectation

# Define molecule and populate
mol = Molecule(xyz_file="lih.xyz")
mol.run_pyscf()

# Apply embedding and boson encoding
mol.hf_embedding(active=[1, 2, 5])
hamiltonian = mol.hamiltonian()

# Set parameters for the rest of the experiment
n_qubits = mol.n_active_orbs
n_electrons = mol.n_active_e

# Build circuit
circuit = he_circuit(n_qubits, 3)
# circuit.draw()

n_circuit_parameters = len(circuit.get_parameters())
parameters = np.random.rand(n_circuit_parameters)
circuit.set_parameters(parameters)

print("Timing:", timeit.timeit(lambda: v_expectation(circuit, hamiltonian, 2000, 50, "qwc"), number=5))
# Output:
# This branch: 3.3... seconds
# main branch: 23.7... seconds
```

Quite a big difference...